### PR TITLE
fixed VS project files for Tetris, grow, lsystem, terrain

### DIFF
--- a/cpp/OpenGL/10/VS/Tetris/Tetris.vcxproj
+++ b/cpp/OpenGL/10/VS/Tetris/Tetris.vcxproj
@@ -27,23 +27,23 @@
     <ClInclude Include="..\..\..\Utils\GLBuffer.h" />
     <ClInclude Include="..\..\..\Utils\GLEnv.h" />
     <ClInclude Include="..\..\..\Utils\GLProgram.h" />
+    <ClInclude Include="..\..\..\Utils\GLTexture1D.h" />
     <ClInclude Include="..\..\..\Utils\GLTexture2D.h" />
     <ClInclude Include="..\..\..\Utils\Mat4.h" />
     <ClInclude Include="..\..\..\Utils\ParticleSystem.h" />
     <ClInclude Include="..\..\..\Utils\PlanarMirror.h" />
     <ClInclude Include="..\..\..\Utils\PrecomputedParticleSystem.h" />
     <ClInclude Include="..\..\..\Utils\Rand.h" />
-    <ClInclude Include="..\..\..\Utils\ReverseParticleSystem.h" />
     <ClInclude Include="..\..\..\Utils\Tesselation.h" />
     <ClInclude Include="..\..\..\Utils\Vec2.h" />
     <ClInclude Include="..\..\..\Utils\Vec3.h" />
+    <ClInclude Include="..\..\..\Utils\Vec4.h" />
     <ClInclude Include="..\..\Grid.h" />
     <ClInclude Include="..\..\OpenGLRenderer.h" />
     <ClInclude Include="..\..\Renderer.h" />
     <ClInclude Include="..\..\Scene.h" />
     <ClInclude Include="..\..\TetrisConst.h" />
     <ClInclude Include="..\..\TextRenderer.h" />
-    <ClInclude Include="Z:\twitch\lnc\cpp\OpenGL\Utils\Vec4.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Utils\AbstractParticleSystem.cpp" />
@@ -54,6 +54,7 @@
     <ClCompile Include="..\..\..\Utils\GLBuffer.cpp" />
     <ClCompile Include="..\..\..\Utils\GLEnv.cpp" />
     <ClCompile Include="..\..\..\Utils\GLProgram.cpp" />
+    <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp" />
     <ClCompile Include="..\..\..\Utils\GLTexture2D.cpp" />
     <ClCompile Include="..\..\..\Utils\Mat4.cpp" />
     <ClCompile Include="..\..\..\Utils\ParticleSystem.cpp" />
@@ -62,12 +63,12 @@
     <ClCompile Include="..\..\..\Utils\Rand.cpp" />
     <ClCompile Include="..\..\..\Utils\Tesselation.cpp" />
     <ClCompile Include="..\..\..\Utils\Vec3.cpp" />
+    <ClCompile Include="..\..\..\Utils\Vec4.cpp" />
     <ClCompile Include="..\..\Grid.cpp" />
     <ClCompile Include="..\..\main.cpp" />
     <ClCompile Include="..\..\OpenGLRenderer.cpp" />
     <ClCompile Include="..\..\Scene.cpp" />
     <ClCompile Include="..\..\TextRenderer.cpp" />
-    <ClCompile Include="Z:\twitch\lnc\cpp\OpenGL\Utils\Vec4.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/cpp/OpenGL/10/VS/Tetris/Tetris.vcxproj.filters
+++ b/cpp/OpenGL/10/VS/Tetris/Tetris.vcxproj.filters
@@ -69,9 +69,6 @@
     <ClInclude Include="..\..\..\Utils\Rand.h">
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\Utils\ReverseParticleSystem.h">
-      <Filter>Headerdateien\Utils</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\Utils\Tesselation.h">
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
@@ -79,9 +76,6 @@
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Utils\Vec3.h">
-      <Filter>Headerdateien\Utils</Filter>
-    </ClInclude>
-    <ClInclude Include="Z:\twitch\lnc\cpp\OpenGL\Utils\Vec4.h">
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\OpenGLRenderer.h">
@@ -95,6 +89,12 @@
     </ClInclude>
     <ClInclude Include="..\..\TextRenderer.h">
       <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Utils\Vec4.h">
+      <Filter>Headerdateien\Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Utils\GLTexture1D.h">
+      <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -161,7 +161,10 @@
     <ClCompile Include="..\..\..\Utils\Vec3.cpp">
       <Filter>Quelldateien\Utils</Filter>
     </ClCompile>
-    <ClCompile Include="Z:\twitch\lnc\cpp\OpenGL\Utils\Vec4.cpp">
+    <ClCompile Include="..\..\..\Utils\Vec4.cpp">
+      <Filter>Quelldateien\Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp">
       <Filter>Quelldateien\Utils</Filter>
     </ClCompile>
   </ItemGroup>

--- a/cpp/OpenGL/11/VS/grow/grow.vcxproj
+++ b/cpp/OpenGL/11/VS/grow/grow.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="..\..\..\Utils\GLBuffer.cpp" />
     <ClCompile Include="..\..\..\Utils\GLEnv.cpp" />
     <ClCompile Include="..\..\..\Utils\GLProgram.cpp" />
+    <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp" />
     <ClCompile Include="..\..\..\Utils\GLTexture2D.cpp" />
     <ClCompile Include="..\..\..\Utils\Mat4.cpp" />
     <ClCompile Include="..\..\..\Utils\ParticleSystem.cpp" />
@@ -192,6 +193,7 @@
     <ClInclude Include="..\..\..\Utils\GLBuffer.h" />
     <ClInclude Include="..\..\..\Utils\GLEnv.h" />
     <ClInclude Include="..\..\..\Utils\GLProgram.h" />
+    <ClInclude Include="..\..\..\Utils\GLTexture1D.h" />
     <ClInclude Include="..\..\..\Utils\GLTexture2D.h" />
     <ClInclude Include="..\..\..\Utils\Mat4.h" />
     <ClInclude Include="..\..\..\Utils\ParticleSystem.h" />

--- a/cpp/OpenGL/11/VS/grow/grow.vcxproj.filters
+++ b/cpp/OpenGL/11/VS/grow/grow.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\..\..\Utils\Vec4.cpp">
       <Filter>Quelldateien\Utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp">
+      <Filter>Quelldateien\Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Utils\bmp.h">
@@ -136,6 +139,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Octree.h">
       <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Utils\GLTexture1D.h">
+      <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/cpp/OpenGL/12/VS/lsystem/lsystem.vcxproj
+++ b/cpp/OpenGL/12/VS/lsystem/lsystem.vcxproj
@@ -167,6 +167,7 @@
     <ClCompile Include="..\..\..\Utils\GLBuffer.cpp" />
     <ClCompile Include="..\..\..\Utils\GLEnv.cpp" />
     <ClCompile Include="..\..\..\Utils\GLProgram.cpp" />
+    <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp" />
     <ClCompile Include="..\..\..\Utils\GLTexture2D.cpp" />
     <ClCompile Include="..\..\..\Utils\Mat4.cpp" />
     <ClCompile Include="..\..\..\Utils\Rand.cpp" />
@@ -178,6 +179,7 @@
     <ClInclude Include="..\..\..\Utils\GLBuffer.h" />
     <ClInclude Include="..\..\..\Utils\GLEnv.h" />
     <ClInclude Include="..\..\..\Utils\GLProgram.h" />
+    <ClInclude Include="..\..\..\Utils\GLTexture1D.h" />
     <ClInclude Include="..\..\..\Utils\GLTexture2D.h" />
     <ClInclude Include="..\..\..\Utils\Mat4.h" />
     <ClInclude Include="..\..\..\Utils\Rand.h" />

--- a/cpp/OpenGL/12/VS/lsystem/lsystem.vcxproj.filters
+++ b/cpp/OpenGL/12/VS/lsystem/lsystem.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="..\..\..\Utils\GLTexture2D.cpp">
       <Filter>Quelldateien\Utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp">
+      <Filter>Quelldateien\Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Utils\GLArray.h">
@@ -72,6 +75,9 @@
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Utils\GLTexture2D.h">
+      <Filter>Headerdateien\Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Utils\GLTexture1D.h">
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cpp/OpenGL/terrain/VS/terrain/terrain.vcxproj
+++ b/cpp/OpenGL/terrain/VS/terrain/terrain.vcxproj
@@ -108,6 +108,12 @@
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\..\VS\lib\Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>opengl32.lib;glew32s.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>XCOPY "$(ProjectDir)..\..\*.bmp" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.bmp" "$(ProjectDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(ProjectDir)*.*" /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -127,6 +133,12 @@
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\..\VS\lib\Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>opengl32.lib;glew32s.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>XCOPY "$(ProjectDir)..\..\*.bmp" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.bmp" "$(ProjectDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(ProjectDir)*.*" /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -142,6 +154,12 @@
       <AdditionalDependencies>opengl32.lib;glew32s.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\..\VS\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PostBuildEvent>
+      <Command>XCOPY "$(ProjectDir)..\..\*.bmp" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.bmp" "$(ProjectDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(ProjectDir)*.*" /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -161,6 +179,12 @@
       <AdditionalDependencies>opengl32.lib;glew32s.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\..\VS\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PostBuildEvent>
+      <Command>XCOPY "$(ProjectDir)..\..\*.bmp" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(OutDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.bmp" "$(ProjectDir)*.*" /Y
+XCOPY "$(ProjectDir)..\..\*.glsl" "$(ProjectDir)*.*" /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Utils\bmp.cpp" />
@@ -173,6 +197,7 @@
     <ClCompile Include="..\..\..\Utils\Mat4.cpp" />
     <ClCompile Include="..\..\..\Utils\Rand.cpp" />
     <ClCompile Include="..\..\..\Utils\Vec3.cpp" />
+    <ClCompile Include="..\..\..\Utils\Vec4.cpp" />
     <ClCompile Include="..\..\Grid2D.cpp" />
     <ClCompile Include="..\..\main.cpp" />
   </ItemGroup>
@@ -189,7 +214,15 @@
     <ClInclude Include="..\..\..\Utils\Rand.h" />
     <ClInclude Include="..\..\..\Utils\Vec2.h" />
     <ClInclude Include="..\..\..\Utils\Vec3.h" />
+    <ClInclude Include="..\..\..\Utils\Vec4.h" />
     <ClInclude Include="..\..\Grid2D.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\param.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\terrain-fs.glsl" />
+    <None Include="..\..\terrain-vs.glsl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/cpp/OpenGL/terrain/VS/terrain/terrain.vcxproj.filters
+++ b/cpp/OpenGL/terrain/VS/terrain/terrain.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClCompile Include="..\..\..\Utils\GLTexture1D.cpp">
       <Filter>Quelldateien\Utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Utils\Vec4.cpp">
+      <Filter>Quelldateien\Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Utils\bmp.h">
@@ -95,8 +98,24 @@
     <ClInclude Include="..\..\..\Utils\GLTexture1D.h">
       <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\Utils\Camera.h">
-      <Filter>Quelldateien\Utils</Filter>
+    <ClInclude Include="..\..\..\Utils\Vec4.h">
+      <Filter>Headerdateien\Utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Utils\Camera.h">
+      <Filter>Headerdateien\Utils</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\param.bmp">
+      <Filter>Ressourcendateien</Filter>
+    </Image>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\terrain-fs.glsl">
+      <Filter>Ressourcendateien</Filter>
+    </None>
+    <None Include="..\..\terrain-vs.glsl">
+      <Filter>Ressourcendateien</Filter>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Tetris:
- relative path for Vec4.h + Vec4.cpp
- removed link to ReverseParticleSystem.h (doesnt exist anymore)

grow+lsystem:
- forced but unused dependency for GLTexture1D.h
(TODO: refactor GLProgram::setTexture -> should be a member of GLTexture*D.h ?)

terrain:
- added pre build event to copy .glsl + .bmp files to VS OutDir
- added dependency for Vec4.h +Vec4.cpp
- Camera.h is now listet as a header file