### PR TITLE
use source_location for checkGLError()

### DIFF
--- a/cpp/OpenGL/Utils/GLEnv.cpp
+++ b/cpp/OpenGL/Utils/GLEnv.cpp
@@ -10,10 +10,12 @@ typedef std::chrono::high_resolution_clock Clock;
 #include "GLEnv.h"
 
 
-void GLEnv::checkGLError(const std::string& id) {
+void GLEnv::checkGLError(const std::string& id, std::experimental::source_location where) {
 	GLenum e = glGetError();
 	if (e != GL_NO_ERROR) {
-		std::cerr << "An openGL error occured:" << e << " at " << id << std::endl;
+		std::cerr << "An openGL error occured:" << e << " at " << id
+			<< " in " << where.file_name() << ":" << where.line()
+			<< std::endl;
 	}
 }
 

--- a/cpp/OpenGL/Utils/GLEnv.h
+++ b/cpp/OpenGL/Utils/GLEnv.h
@@ -3,6 +3,7 @@
 #include <exception>
 #include <string>
 #include <chrono>
+#include <experimental/source_location>
 
 #include <GL/glew.h>  
 #include <GLFW/glfw3.h>
@@ -38,7 +39,7 @@ class GLEnv {
 		void setFPSCounter(bool fpsCounter);
 		void setSync(bool sync);
 
-		static void checkGLError(const std::string& id);
+		static void checkGLError(const std::string& id, std::experimental::source_location where = std::experimental::source_location::current());
 
 	private:
 		GLFWwindow* window;


### PR DESCRIPTION
This automatically adds the location of the checkGLError() call to its output. This could actually make the parameter "at" obsolte, too, but I didn't want to change the api.

experimental/source_location is a standard c++ library extension for c++ 17, it will likely be included in c++ 20. The portable solution for older c++ versions would be to use `__FILE__` and `__LINE__` inside a macro.

`#define checkGLError() checkGLErrorInternal(__FILE__, __LINE__)`