### PR TITLE
Pr/02 torus life

### DIFF
--- a/cpp/OpenGL/GameOfLife/main.cpp
+++ b/cpp/OpenGL/GameOfLife/main.cpp
@@ -38,6 +38,7 @@ GLBuffer ibTorus{GL_ELEMENT_ARRAY_BUFFER};
 GLArray torusArray;
 GLProgram progTorus{GLProgram::createFromFile("visualizeVS.glsl", "visualizeFS.glsl")};
 
+bool drawTorus{false};
 
 void randomizeGrid() {
   std::vector<uint8_t> data(gridTextures[0].getSize());
@@ -67,6 +68,9 @@ static void keyCallback(GLFWwindow* window, int key, int scancode, int action, i
       case GLFW_KEY_C:
         clearGrid();
         break;
+      case GLFW_KEY_T:
+	drawTorus = !drawTorus;
+	break;
     }
   }
 }
@@ -193,7 +197,11 @@ int main(int argc, char** argv) {
     
   GLEnv::checkGLError("BeforeFirstLoop");
   do {
-    renderTorus();
+    if (drawTorus) {
+      renderTorus();
+    } else {
+      render();
+    }
     evolve();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     GLEnv::checkGLError("endOfFrame");

--- a/cpp/OpenGL/Utils/Tesselation.cpp
+++ b/cpp/OpenGL/Utils/Tesselation.cpp
@@ -1,6 +1,8 @@
 #include <cmath>
 #include <iostream>
 
+#include "Vec2.h"
+
 constexpr float PI = 3.14159265358979323846f;
 
 #include "Tesselation.h"
@@ -318,5 +320,58 @@ Tesselation Tesselation::genBrick(const Vec3& center, const Vec3& size, const Ve
 		20,21,22,20,22,23
 	};
 	
+	return tess;
+}
+
+// Torus
+// can be moved around by center, but the normal to the torus plane is always (0, 0, 1)
+Tesselation Tesselation::genTorus(const Vec3 &center, float majorRadius, float minorRadius, uint32_t majorSteps, uint32_t minorSteps) {
+	Tesselation tess{};
+
+	for (uint32_t x = 0; x <= majorSteps; x++) {
+		const float phi = (2.0f * PI * x) / majorSteps;
+		for (uint32_t y = 0; y <= minorSteps; y++) {
+			const float theta = (2.0 * PI * y) / minorSteps;
+
+			const Vec3 vertice{(majorRadius + minorRadius*std::cos(theta))*std::cos(phi),
+					   (majorRadius + minorRadius*std::cos(theta))*std::sin(phi),
+					   minorRadius * std::sin(theta)};
+			const Vec3 normal{Vec3::normalize(vertice - Vec3{majorRadius*std::cos(phi), majorRadius*std::sin(phi), 0})};
+			// select tangent in toroidal direction
+			const Vec3 tangent{-majorRadius*std::sin(phi), majorRadius*std::cos(phi), 0};
+			const Vec2 texture{static_cast<float>(x)/static_cast<float>(majorSteps),
+					   static_cast<float>(y)/static_cast<float>(minorSteps)};
+
+
+			tess.vertices.push_back(vertice.x() + center.x());
+			tess.vertices.push_back(vertice.y() + center.y());
+			tess.vertices.push_back(vertice.z() + center.z());
+
+			tess.normals.push_back(normal.x());
+			tess.normals.push_back(normal.y());
+			tess.normals.push_back(normal.z());
+
+			tess.tangents.push_back(tangent.x());
+			tess.tangents.push_back(tangent.y());
+			tess.tangents.push_back(tangent.z());
+
+			tess.texCoords.push_back(texture.x());
+			tess.texCoords.push_back(texture.y());
+		}
+	}
+
+	for (uint32_t x = 0; x < majorSteps; x++) {
+		for (uint32_t y = 0; y < minorSteps; y++) {
+			// push 2 triangles per point
+			tess.indices.push_back((x+0)*(minorSteps+1) + (y+0));
+			tess.indices.push_back((x+1)*(minorSteps+1) + (y+0));
+			tess.indices.push_back((x+1)*(minorSteps+1) + (y+1));
+
+			tess.indices.push_back((x+0)*(minorSteps+1) + (y+0));
+			tess.indices.push_back((x+1)*(minorSteps+1) + (y+1));
+			tess.indices.push_back((x+0)*(minorSteps+1) + (y+1));
+		}
+	}
+
 	return tess;
 }

--- a/cpp/OpenGL/Utils/Tesselation.h
+++ b/cpp/OpenGL/Utils/Tesselation.h
@@ -9,6 +9,7 @@ class Tesselation {
 		static Tesselation genRectangle(const Vec3& center, const float width, const float height);
 		static Tesselation genRectangle(const Vec3& a, const Vec3& b, const Vec3& c, const Vec3& d);
 		static Tesselation genBrick(const Vec3& center, const Vec3& size, const Vec3& texScale=Vec3{1,1,1});
+		static Tesselation genTorus(const Vec3 &center, float majorRadius, float minorRadius, uint32_t majorSteps=200, uint32_t minorSteps=50);
 
 		const std::vector<float>& getVertices() const {return vertices;}
 		const std::vector<float>& getNormals() const {return normals;}


### PR DESCRIPTION
Render the cyclic playing field of game of life on a torus.

Adds a new torus tessellation object, and a switch between frontal rendering and torus using the `T` key. The intuitiveness of drawing new cells is broken, it still works as if the drawing plane would be frontal facing.