### PR TITLE
Evolution rules now editable; switch for rendermode; VS-files updated

### DIFF
--- a/cpp/OpenGL/GameOfLife3D/VS/GameOfLife3D/GameOfLife3D.vcxproj
+++ b/cpp/OpenGL/GameOfLife3D/VS/GameOfLife3D/GameOfLife3D.vcxproj
@@ -219,6 +219,8 @@ XCOPY "$(ProjectDir)..\..\*.glsl" "$(ProjectDir)*.*" /Y</Command>
     <None Include="..\..\evolveFS.glsl" />
     <None Include="..\..\evolveVS.glsl" />
     <None Include="..\..\frontFS.glsl" />
+    <None Include="..\..\stereoFS.glsl" />
+    <None Include="..\..\stereoVS.glsl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/cpp/OpenGL/GameOfLife3D/VS/GameOfLife3D/GameOfLife3D.vcxproj.filters
+++ b/cpp/OpenGL/GameOfLife3D/VS/GameOfLife3D/GameOfLife3D.vcxproj.filters
@@ -142,5 +142,11 @@
     <None Include="..\..\evolveVS.glsl">
       <Filter>Ressourcendateien</Filter>
     </None>
+    <None Include="..\..\stereoFS.glsl">
+      <Filter>Ressourcendateien</Filter>
+    </None>
+    <None Include="..\..\stereoVS.glsl">
+      <Filter>Ressourcendateien</Filter>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
how to edit the rules:
- move the position of editpoint in the deathMap or birthMap by Arrow keys left, right
- press "d" or "b" to flip the Bit in deathMap or birthMap

chose render mode: "1" standart or "2" anaglyph