### PR TITLE
Changed the makefiles of cpp/Raytrace and cpp/OpenGL

### DIFF
--- a/cpp/OpenGL/01_SimpleTriangle/makefile
+++ b/cpp/OpenGL/01_SimpleTriangle/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = triangle

--- a/cpp/OpenGL/02_SimpleTriangle_GLEnv/makefile
+++ b/cpp/OpenGL/02_SimpleTriangle_GLEnv/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = triangle

--- a/cpp/OpenGL/03_Cube/makefile
+++ b/cpp/OpenGL/03_Cube/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = cube

--- a/cpp/OpenGL/04_Lighting/makefile
+++ b/cpp/OpenGL/04_Lighting/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = sphere

--- a/cpp/OpenGL/05_Texture/makefile
+++ b/cpp/OpenGL/05_Texture/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = texture

--- a/cpp/OpenGL/06_NormalMapping/makefile
+++ b/cpp/OpenGL/06_NormalMapping/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = bump

--- a/cpp/OpenGL/07_Particles/makefile
+++ b/cpp/OpenGL/07_Particles/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = particle

--- a/cpp/OpenGL/08_MirrorScene/makefile
+++ b/cpp/OpenGL/08_MirrorScene/makefile
@@ -1,8 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS= -lglfw -lglew -framework OpenGL -L../Utils -lutils 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = Scene.cpp main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = mirror

--- a/cpp/OpenGL/09_Tetris/makefile
+++ b/cpp/OpenGL/09_Tetris/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
+
 SRC = OpenGLRenderer.cpp Grid.cpp Scene.cpp main.cpp TextRenderer.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = tetris

--- a/cpp/OpenGL/10_Dendrite_Growth/makefile
+++ b/cpp/OpenGL/10_Dendrite_Growth/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -pthread
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -pthread
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L../../openmp/lib
+	INCLUDES=-I. -I../Utils -I../../openmp/include
+endif
+
 SRC = Octree.cpp main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = grow

--- a/cpp/OpenGL/11_L-System/makefile
+++ b/cpp/OpenGL/11_L-System/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = lsystem

--- a/cpp/OpenGL/12_GameOfLife/makefile
+++ b/cpp/OpenGL/12_GameOfLife/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Wno-deprecated-declarations
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Wno-deprecated-declarations
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -Wno-deprecated-declarations
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = gol

--- a/cpp/OpenGL/13_GameOfLife3D/makefile
+++ b/cpp/OpenGL/13_GameOfLife3D/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Wno-deprecated-declarations
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Wno-deprecated-declarations
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -Wno-deprecated-declarations
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = gol3

--- a/cpp/OpenGL/14_TerrainSynthesis/makefile
+++ b/cpp/OpenGL/14_TerrainSynthesis/makefile
@@ -1,11 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
 
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include 
 SRC = main.cpp GradientGenerator.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = terrain

--- a/cpp/OpenGL/15_Splines/makefile
+++ b/cpp/OpenGL/15_Splines/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = splines

--- a/cpp/OpenGL/16_OBJ/makefile
+++ b/cpp/OpenGL/16_OBJ/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = mesh

--- a/cpp/OpenGL/17_Color/makefile
+++ b/cpp/OpenGL/17_Color/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = raster

--- a/cpp/OpenGL/18_Intersect/makefile
+++ b/cpp/OpenGL/18_Intersect/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = sphere

--- a/cpp/OpenGL/19_Asteroids/makefile
+++ b/cpp/OpenGL/19_Asteroids/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = asteroids

--- a/cpp/OpenGL/20_ShapeDesigner/makefile
+++ b/cpp/OpenGL/20_ShapeDesigner/makefile
@@ -1,9 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=
-INCLUDES=-I. -I../Utils
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=
+	INCLUDES=-I. -I../Utils
+endif
+
 SRC = main.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = designer

--- a/cpp/OpenGL/21_Digits/makefile
+++ b/cpp/OpenGL/21_Digits/makefile
@@ -1,9 +1,18 @@
 CC=g++
+OSTYPE := $(shell uname)
 
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../LibML -lml -L../Utils -lutils
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../LibML -I../Utils -I ../../openmp/include 
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../LibML -lml -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../LibML -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../LibML -lml -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../LibML -I../Utils -I ../../openmp/include 
+endif
+
 SRC = main.cpp MNIST.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = digits

--- a/cpp/OpenGL/LibML/makefile
+++ b/cpp/OpenGL/LibML/makefile
@@ -1,10 +1,20 @@
 CC=g++
 AR=ar
 ARFLAGS= rcs
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I ../../openmp/include
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-fopenmp
+	LIBS=
+	INCLUDES=-I. 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I ../../openmp/include 
+endif
+
 SRC = LA.cpp BPNetwork.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = libml.a

--- a/cpp/OpenGL/Utils/OBJFile.cpp
+++ b/cpp/OpenGL/Utils/OBJFile.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <algorithm>
 
 #include "OBJFile.h"
 

--- a/cpp/OpenGL/Utils/makefile
+++ b/cpp/OpenGL/Utils/makefile
@@ -1,11 +1,20 @@
 CC=g++
 AR=ar
 ARFLAGS= rcs
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils 
-# for linux use this line LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils
-LIBS=-lomp -L ../../openmp/lib
-INCLUDES=-I. -I../Utils -I ../../openmp/include
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-lglfw -lGLEW -lGL -L../Utils -lutils -fopenmp
+	LIBS=
+	INCLUDES=-I. -I../Utils 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=-lglfw -lGLEW -framework OpenGL -L../Utils -lutils
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I../Utils -I ../../openmp/include 
+endif
+
 SRC = Mat3.cpp GLApp.cpp ArcBall.cpp GLTexture3D.cpp GLDebug.cpp GLFramebuffer.cpp GLDepthBuffer.cpp Grid2D.cpp GLTexture1D.cpp Vec4.cpp FontRenderer.cpp bmp.cpp PrecomputedParticleSystem.cpp PlanarMirror.cpp FresnelVisualizer.cpp GLArray.cpp ParticleSystem.cpp AbstractParticleSystem.cpp GLTexture2D.cpp Tesselation.cpp GLBuffer.cpp GLEnv.cpp GLProgram.cpp Mat4.cpp Vec3.cpp Rand.cpp OBJFile.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = libutils.a

--- a/cpp/OpenGL/makefile
+++ b/cpp/OpenGL/makefile
@@ -1,6 +1,11 @@
+# use make to compile all projects on linux or mac
+# on linux you need the following:
+# sudo apt install -y libglu1-mesa-dev freeglut3-dev mesa-common-dev xorg-dev mesa-utils libglfw3-dev libglew-dev libomp-dev
+
 TOPTARGETS := all clean
 
 SUBDIRS := $(wildcard */.)
+SUBDIRS := $(filter-out Utils/. VS/. LibML/.,$(SUBDIRS))
 
 $(TOPTARGETS): $(SUBDIRS)
 $(SUBDIRS):

--- a/cpp/Raytrace/makefile
+++ b/cpp/Raytrace/makefile
@@ -1,8 +1,18 @@
 CC=g++
-CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
-LFLAGS=
-LIBS=-lomp -L ../openmp/lib
-INCLUDES=-I.
+OSTYPE := $(shell uname)
+
+ifeq ($(OSTYPE),Linux)
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -fopenmp
+	LFLAGS=-fopenmp
+	LIBS=
+	INCLUDES=-I. 
+else
+	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
+	LFLAGS=
+	LIBS=-lomp -L ../../openmp/lib
+	INCLUDES=-I. -I ../openmp/include 
+endif
+
 SRC = Rand.cpp HitableList.cpp HitRecord.cpp main.cpp Vec3.cpp Ray.cpp Camera.cpp Sphere.cpp Dielectric.cpp Metal.cpp Lambertian.cpp Mat4.cpp
 OBJ = $(SRC:.cpp=.o)
 TARGET = raytrace


### PR DESCRIPTION
Changed the make files of _cpp/Raytrace_ and _cpp/OpenGL_ in order to make the projects able to compile after vanilla git clone.
The make files will either detect a Linux System and set corresponding compiler flags for Linux or use default flags for Mac.
Tested on Debian 10 with packages: `sudo apt install -y libglu1-mesa-dev freeglut3-dev mesa-common-dev xorg-dev mesa-utils libglfw3-dev libglew-dev libomp-dev`.

Can someone test if the builds are still working on Mac?
```
cd cpp/Raytrace && make clean && make && \
cd ../OpenGL && make clean && make
```