### PR TITLE
added #include <algorithm> for std::clamp (needed for Visual Studio)

### DIFF
--- a/cpp/OpenGL/Vis_02_MC/MC.cpp
+++ b/cpp/OpenGL/Vis_02_MC/MC.cpp
@@ -1,5 +1,6 @@
 #include "MC.h"
 #include "MC.inl"
+#include <algorithm> // std::clamp
 
 Isosurface::Isosurface(const Volume& volume, uint8_t isovalue) {
   for (size_t l = 0; l < volume.depth-1; ++l) {


### PR DESCRIPTION
Visual Studio 2019 cannot find std::clamp without including <algorithm>.
See: https://en.cppreference.com/w/cpp/algorithm/clamp