### PR TITLE
Tiny linuxify

### DIFF
--- a/cpp/OpenGL/Utils/Grid2D.cpp
+++ b/cpp/OpenGL/Utils/Grid2D.cpp
@@ -386,7 +386,7 @@ static const float INV = std::numeric_limits<float>::max();
 static const Vec2ui NO_POS{std::numeric_limits<uint32_t>::max(),
                     std::numeric_limits<uint32_t>::max()};
 static float dist(size_t x, size_t y, const Vec2ui& p) {
-  return std::sqrtf( (x-p.x())*(x-p.x()) + (y-p.y())*(y-p.y()) );
+  return sqrtf( (x-p.x())*(x-p.x()) + (y-p.y())*(y-p.y()) );
 }
 
 Grid2D Grid2D::toSignedDistance(float threshold) const {

--- a/cpp/OpenGL/makefile
+++ b/cpp/OpenGL/makefile
@@ -4,10 +4,11 @@
 
 TOPTARGETS := all clean release
 
-SUBDIRS := $(wildcard */.)
-SUBDIRS := $(filter-out VS/. Utils/. LibML/. Network/.,$(SUBDIRS))
-FIRSTDIR := LibML/. Network/.
 UTILSDIR := Utils/.
+FIRSTDIR := LibML/. Network/.
+
+SUBDIRS := $(wildcard */.)
+SUBDIRS := $(filter-out VS/. $(UTILSDIR) $(FIRSTDIR),$(SUBDIRS))
 
 $(TOPTARGETS): $(SUBDIRS)
 


### PR DESCRIPTION
- compiling with `std::sqrtf` throws a compiler error on Linux.
- altered the makefile as it is better to write the directories only once