### PR TITLE
Stresstest auf websockets

### DIFF
--- a/cpp/OpenGL/36_Websocket/VS/SocketServer.vcxproj
+++ b/cpp/OpenGL/36_Websocket/VS/SocketServer.vcxproj
@@ -37,7 +37,6 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -50,7 +49,6 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -75,28 +73,28 @@
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(SolutionDir)..\..\VS\include;$(SolutionDir)..\..\Utils;$(SolutionDir)..\..\Network;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(SolutionDir)..\..\VS\include;$(SolutionDir)..\..\Utils;$(SolutionDir)..\..\Network;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(SolutionDir)..\..\VS\include;$(SolutionDir)..\..\Utils;$(SolutionDir)..\..\Network;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(SolutionDir)..\..\VS\include;$(SolutionDir)..\..\Utils;$(SolutionDir)..\..\Network;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/cpp/OpenGL/36_Websocket/VS/SocketServer.vcxproj
+++ b/cpp/OpenGL/36_Websocket/VS/SocketServer.vcxproj
@@ -23,33 +23,33 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{043f4539-6d64-4ba7-8151-fce78c20d871}</ProjectGuid>
     <RootNamespace>SocketServer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectName>SocketServer</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -105,7 +105,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@ XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -142,13 +142,8 @@ XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
       <AdditionalDependencies>network.lib;utils.lib;opengl32.lib;glew32s.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>XCOPY "$(ProjectDir)..\*.bmp" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.glsl" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.pos" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.bmp" "$(ProjectDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.glsl" "$(ProjectDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
-</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -157,7 +152,7 @@ XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -166,13 +161,8 @@ XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\VS\lib\$(Platform);$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>XCOPY "$(ProjectDir)..\*.bmp" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.glsl" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.pos" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.bmp" "$(ProjectDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.glsl" "$(ProjectDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
-</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -183,7 +173,7 @@ XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;GLEW_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -194,13 +184,8 @@ XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\VS\lib\$(Platform);$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>XCOPY "$(ProjectDir)..\*.bmp" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.glsl" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.pos" "$(OutDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.bmp" "$(ProjectDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.glsl" "$(ProjectDir)*.*" /Y
-XCOPY "$(ProjectDir)..\*.pos" "$(ProjectDir)*.*" /Y
-</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/cpp/OpenGL/36_Websocket/test.html
+++ b/cpp/OpenGL/36_Websocket/test.html
@@ -167,9 +167,9 @@
         ctx.fillStyle = "rgba(0,0,255,0.1)";
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         
-        socket = new WebSocket('ws://134.91.11.186:2000');
+        //socket = new WebSocket('ws://134.91.11.186:2000');
         //socket = new WebSocket('ws://134.91.11.162:2000');
-        //socket = new WebSocket('ws://localhost:2000');
+        socket = new WebSocket('ws://localhost:2000');
         
         socket.onopen = function () {
           document.getElementById("status").innerHTML += "Connection open<br>";

--- a/cpp/OpenGL/36_Websocket/test_connect_disconnect.html
+++ b/cpp/OpenGL/36_Websocket/test_connect_disconnect.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>WebSocket Multiuser Painter</title>
+  <script type="text/javascript">
+
+  var socket;
+
+  //https://stackoverflow.com/questions/951021/what-is-the-javascript-version-of-sleep
+  //"neueste art", na von mir aus.
+    function sleep(ms) {
+      console.log("sleep " + ms +"ms");
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async function init() {
+      
+      const nMax=500;
+      
+      for (var i = 0; i < nMax; i++) {
+        try{
+        //socket = new WebSocket('ws://134.91.11.186:2000');
+        //socket = new WebSocket('ws://134.91.11.162:2000');
+        socket = new WebSocket('ws://localhost:2000');
+
+        if( (i+1)>=nMax)
+        {
+          //detail vom firefox: solange firefox.exe im taskmanager existiert
+          //versucht diese alle new Websockets nachzuholen, selbst wenn der browsertab schon zu ist.
+          //bei reload schickt es keinen socket close.
+          document.location.reload(true); 
+        }
+
+        socket.onopen = function () {
+          document.getElementById("status").innerHTML += "Connection open<br>";
+        };
+
+        socket.onmessage = function (msg) {
+          if (typeof msg.data === "string")
+            document.getElementById("status").innerHTML += "Received String Message: " + msg.data + "<br>";
+          else {
+            // let reader = new FileReader();
+            // reader.readAsArrayBuffer(msg.data);
+            // reader.addEventListener("loadend", function (e) {
+            //   processBuffer(new Uint8Array(e.target.result))
+            // });
+          }
+        };
+
+        socket.onclose = function () {
+          document.getElementById("status").innerHTML += "Connection closed" + "<br>";
+        };
+
+        await sleep(50);
+        console.log("about to close");
+        await socket.close();
+        socket = null;
+        }
+        catch(e)
+        {
+          console.log(e);
+        }
+      
+      }
+      
+    }
+
+   
+  </script>
+</head>
+
+<body onload="init();" style="background-color:#BBBBBB;">
+  <center>
+    <h1 id="title">Connecting to Paint-Server</h1>
+    <canvas id="drawArea" width="1000" height="1000"></canvas>
+    <p id="status"></p>
+  </center>
+</body>
+
+</html>

--- a/cpp/OpenGL/Network/Server.h
+++ b/cpp/OpenGL/Network/Server.h
@@ -299,29 +299,25 @@ void Server<T>::clientFunc() {
       } catch (const SocketException&) {
       }
       
-      DataResult message = DataResult::NO_DATA;
+      
       try {
-        message = clientConnections[i]->checkData();
-      } catch (SocketException const& ) {
-        removeClient(i);
-        continue;
-      }
-
-      try {
-        if (message != DataResult::NO_DATA) {
+		const std::shared_ptr<T>& client = clientConnections[i];
+		const DataResult message = client->checkData();
+        
+		if (message != DataResult::NO_DATA) {
           idle = false;
           switch (message) {
             case DataResult::STRING_DATA:
-              handleClientMessage(clientConnections[i]->getID(), std::move(clientConnections[i]->strData));
+              handleClientMessage(client->getID(), std::move(client->strData));
               break;
             case DataResult::BINARY_DATA:
-              handleClientMessage(clientConnections[i]->getID(), std::move(clientConnections[i]->binData));
+              handleClientMessage(client->getID(), std::move(client->binData));
               break;
             case DataResult::PROTOCOL_DATA:
-              handleProtocolMessage(clientConnections[i]->getID(), clientConnections[i]->protocolDataID, std::move(clientConnections[i]->binData));
+              handleProtocolMessage(client->getID(), client->protocolDataID, std::move(client->binData));
               break;
             case DataResult::NO_DATA:
-              // never hit, silnce warning
+              // never hit, silence warning
               break;
           }
         }

--- a/cpp/OpenGL/Network/Sockets.cpp
+++ b/cpp/OpenGL/Network/Sockets.cpp
@@ -1,5 +1,5 @@
 #include "Sockets.h"
-
+#include <iostream>
 #ifdef _WIN32
   #define DETECTED_OS_WINDOWS
 #elif defined(macintosh) || (defined(__MACH__) && defined(__APPLE__))
@@ -261,7 +261,11 @@ bool Socket::IsBound() const
 void Socket::Bind(const NetworkAddress & address)
 {
   if (bind(m_Socket, &address.GetNativeAddress(), sizeof(sockaddr)) == SOCKET_ERROR) throw SocketException("Could not bind socket.", "bind", GetError());
-
+	
+  std::string boundAdress;
+  uint16_t boundPort=0;
+  address.GetAddress(boundAdress, boundPort);
+  std::cout << "Bound to: " << boundAdress.c_str() << ":" << boundPort << "\n";
   // below applies for listen sockets
   // we may need to consider this and reimplement Bind for ListenSocket
   // use getsockname here to determine address and port assigned to socket (should be any address, 0.0.0.0)

--- a/cpp/OpenGL/Network/VS/Network.vcxproj
+++ b/cpp/OpenGL/Network/VS/Network.vcxproj
@@ -54,7 +54,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -67,7 +66,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -91,25 +89,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\Utils;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\Utils;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\Utils;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\Utils;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -123,6 +121,7 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -147,6 +146,7 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -171,6 +171,7 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -195,6 +196,7 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/cpp/OpenGL/Network/VS/Network.vcxproj
+++ b/cpp/OpenGL/Network/VS/Network.vcxproj
@@ -41,32 +41,32 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{13ABC8A2-39FF-49CE-A88C-CE9BCD95458C}</ProjectGuid>
     <RootNamespace>Network</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -122,8 +122,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -147,8 +146,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -172,8 +170,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -197,8 +194,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/cpp/OpenGL/Utils/MD5.cpp
+++ b/cpp/OpenGL/Utils/MD5.cpp
@@ -1,7 +1,7 @@
 #include "MD5.h"
 #include <memory.h>
 #include <fstream>
-
+#include <algorithm> //std::min
 #define MD5_INIT_STATE_0 0x67452301
 #define MD5_INIT_STATE_1 0xefcdab89
 #define MD5_INIT_STATE_2 0x98badcfe

--- a/cpp/OpenGL/Utils/OBJFile.cpp
+++ b/cpp/OpenGL/Utils/OBJFile.cpp
@@ -1,6 +1,6 @@
 #include <fstream>
 #include <algorithm>
-
+#include <cctype> //std::isspace
 #include "OBJFile.h"
 
 OBJFile::OBJFile(const std::string& filename, bool normalize) {

--- a/cpp/OpenGL/Utils/VS/Utils.vcxproj
+++ b/cpp/OpenGL/Utils/VS/Utils.vcxproj
@@ -108,7 +108,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -121,7 +120,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -144,23 +142,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IntDir>$(SolutionDir)tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(PlatformTarget)-$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)tmp\$(PlatformTarget)-$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)tmp\$(TargetName)\$(PlatformTarget)-$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/cpp/OpenGL/Utils/VS/Utils.vcxproj
+++ b/cpp/OpenGL/Utils/VS/Utils.vcxproj
@@ -95,32 +95,32 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{164a60b9-00ce-4cda-94dd-cc3366859398}</ProjectGuid>
     <RootNamespace>Utils</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -172,8 +172,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -197,8 +196,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -222,8 +220,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -247,8 +244,7 @@
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>../../VS/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <OpenMPSupport>true</OpenMPSupport>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>


### PR DESCRIPTION
Da ich keine Ahnung habe, wie man cherrypicking auf einzelnen commits machen kann, ist in diesem pullrequest einfach mal alles.
Die Änderungen in den visualstudio-projektdateien sind vermutlich ignorierbar.
Kern wäre die test_connect_disconnect.html und server.cpp ..deren aufruf bringt eine cabort-exception (zumindest bei mir).
Anscheinend haben wir konkurrierenden Zugriff auf front, welche sich indirekt in der bereits aufgeräumten messagequeue befindet, sofern destructor der Baseclientconnection und ein sendmessage zusammenlaufen. (timingabhängig, bei sleep(200) in der html passiert nix)
Aktuell "behoben" über Prüfung der continuerunning-variable, damit sendmessage übersprungen wird, wenn wir uns bereits im destructor befinden, das wären die Änderungen in der server.cpp