### PR TITLE
changes to make cpp/OpenCL compile without issues on Debian 11

### DIFF
--- a/cpp/OpenGL/42/YAKTerrain.h
+++ b/cpp/OpenGL/42/YAKTerrain.h
@@ -2,6 +2,8 @@
 
 #include <thread>
 #include <vector>
+#include <mutex>
+#include <condition_variable>
 
 #include <Grid2D.h>
 
@@ -19,26 +21,26 @@ class YAKTerrain {
 public:
   YAKTerrain(const Vec2ui& size);
   ~YAKTerrain();
-    
+
   void requestBricks(const Vec3i& offset=Vec3i{0,0,0});
   bool bricksReady();
   std::vector<ManagedYAK> getBricks();
-  
+
   Vec2ui getSize() const {return size;}
   Vec3i getBrickSize() const {return brickSize;}
-  
+
 private:
   Vec2ui size;
   const Vec3i brickSize{2,2,3};
   Vec3i brickOffset;
-  YAKTerrainStatus status{YAKTerrainStatus::Idle};  
-    
+  YAKTerrainStatus status{YAKTerrainStatus::Idle};
+
   std::mutex statusMutex;
   std::condition_variable cv;
   std::thread generationThread;
-  
+
   StaticYAKCuller culler;
-  
+
   void computeBricks();
   Grid2D generateHeightfield() const;
   void generateBricksFromField(const Grid2D& field);

--- a/cpp/OpenGL/OpenCL/OpenClContext.h
+++ b/cpp/OpenGL/OpenCL/OpenClContext.h
@@ -13,7 +13,7 @@
     #include "CL\cl.hpp"
 #else
     #include "CL/opencl.h"
-    #include "CL/cl.hpp"
+    #include "CL/cl.h"
 #endif
 
 #include <exception>

--- a/cpp/OpenGL/OpenCL/makefile
+++ b/cpp/OpenGL/OpenCL/makefile
@@ -5,14 +5,14 @@ OSTYPE := $(shell uname)
 
 ifeq ($(OSTYPE),Linux)
 	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code
-	LFLAGS--lstdc++fs
+	LFLAGS=-lstdc++fs
 	LIBS=-lOpenCL
 	INCLUDES=-I.
 else
 	CFLAGS=-c -Wall -std=c++17 -Wunreachable-code -Xclang -fopenmp
 	LFLAGS=
 	LIBS=-framework OpenCL
-	INCLUDES=-I. 
+	INCLUDES=-I.
 endif
 
 SRC = OpenClContext.cpp OpenClUtils.cpp Fractal.cpp
@@ -28,8 +28,7 @@ $(TARGET): $(OBJ)
 	$(AR) $(ARFLAGS) $@ $^
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@
+	$(CC) $(CFLAGS) $(INCLUDES) $(LIBS) $^ -o $@
 
 clean:
 	-rm -rf $(OBJ) $(TARGET) core
-

--- a/cpp/OpenGL/makefile
+++ b/cpp/OpenGL/makefile
@@ -1,7 +1,7 @@
 TOPTARGETS := all clean release
 
 UTILSDIR := Utils/.
-FIRSTDIR := LibML/. Network/.
+FIRSTDIR := LibML/. Network/. OpenCL/.
 
 SUBDIRS := $(wildcard */.)
 SUBDIRS := $(filter-out VS/. $(UTILSDIR) $(FIRSTDIR),$(SUBDIRS))


### PR DESCRIPTION
Note: On `Debian 11` `gcc 10` has quite long compile times for the `Network` related projects like `24_Netpaint` or `26_BattleShips` (the issue seems to be the compile flag `-flto` but not exclusively as simply removing it does not improve the compile time).
