### PR TITLE
sprintf entfällt, sha2 refakturiert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@ cpp/**/VS/**/tmp/*
 cpp/**/VS/**/x64/*
 cpp/**/VS/**/*.glsl
 cpp/**/VS/**/*.obj
-/cpp/OpenGL/42/VS/helvetica_neue.pos
-/cpp/OpenGL/42/VS/helvetica_neue.inc
-/cpp/OpenGL/42/VS/helvetica_neue.bmp

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cpp/**/VS/**/tmp/*
 cpp/**/VS/**/x64/*
 cpp/**/VS/**/*.glsl
 cpp/**/VS/**/*.obj
+/cpp/OpenGL/42/VS/helvetica_neue.pos
+/cpp/OpenGL/42/VS/helvetica_neue.inc
+/cpp/OpenGL/42/VS/helvetica_neue.bmp

--- a/cpp/OpenGL/42/VS/.gitignore
+++ b/cpp/OpenGL/42/VS/.gitignore
@@ -1,0 +1,3 @@
+**/helvetica_neue.bmp
+**/helvetica_neue.inc
+**/helvetica_neue.pos

--- a/cpp/OpenGL/42/VS/YAK42.vcxproj
+++ b/cpp/OpenGL/42/VS/YAK42.vcxproj
@@ -55,7 +55,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NOMINMAX;GLEW_STATIC;_MBCS;_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;GLEW_STATIC;_MBCS;_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link />
   </ItemDefinitionGroup>
@@ -67,7 +67,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NOMINMAX;GLEW_STATIC;_MBCS;_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;GLEW_STATIC;_MBCS;_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/cpp/OpenGL/Utils/SHA2.cpp
+++ b/cpp/OpenGL/Utils/SHA2.cpp
@@ -1,466 +1,546 @@
-#define _CRT_SECURE_NO_WARNINGS
 
 #include <cstring>
 #include <fstream>
 #include "SHA2.h"
- 
-const unsigned int SHA256::sha256_k[64] = //UL = uint32
-            {0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
-             0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-             0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-             0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-             0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
-             0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-             0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-             0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-             0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-             0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-             0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
-             0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-             0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
-             0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-             0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-             0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
-const unsigned long long SHA512::sha512_k[80] = //ULL = uint64
-            {0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL,
-             0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
-             0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
-             0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
-             0xd807aa98a3030242ULL, 0x12835b0145706fbeULL,
-             0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
-             0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL,
-             0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
-             0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL,
-             0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
-             0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL,
-             0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
-             0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL,
-             0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
-             0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL,
-             0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
-             0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL,
-             0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
-             0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL,
-             0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
-             0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL,
-             0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
-             0xd192e819d6ef5218ULL, 0xd69906245565a910ULL,
-             0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
-             0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL,
-             0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
-             0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL,
-             0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
-             0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL,
-             0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
-             0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL,
-             0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
-             0xca273eceea26619cULL, 0xd186b8c721c0c207ULL,
-             0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
-             0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL,
-             0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
-             0x28db77f523047d84ULL, 0x32caab7b40c72493ULL,
-             0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
-             0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL,
-             0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL};
- 
-void SHA224::init()
-{
-    m_h[0]=0xc1059ed8;
-    m_h[1]=0x367cd507;
-    m_h[2]=0x3070dd17;
-    m_h[3]=0xf70e5939;
-    m_h[4]=0xffc00b31;
-    m_h[5]=0x68581511;
-    m_h[6]=0x64f98fa7;
-    m_h[7]=0xbefa4fa4;
-    m_len = 0;
-    m_tot_len = 0;
-}
- 
-void SHA224::update(const unsigned char *message, unsigned int len)
-{
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
-    const unsigned char *shifted_message;
-    tmp_len = SHA224_256_BLOCK_SIZE - m_len;
-    rem_len = len < tmp_len ? len : tmp_len;
-    memcpy(&m_block[m_len], message, rem_len);
-    if (m_len + len < SHA224_256_BLOCK_SIZE) {
-        m_len += len;
-        return;
-    }
-    new_len = len - rem_len;
-    block_nb = new_len / SHA224_256_BLOCK_SIZE;
-    shifted_message = message + rem_len;
-    transform(m_block, 1);
-    transform(shifted_message, block_nb);
-    rem_len = new_len % SHA224_256_BLOCK_SIZE;
-    memcpy(m_block, &shifted_message[block_nb << 6], rem_len);
-    m_len = rem_len;
-    m_tot_len += (block_nb + 1) << 6;
-}
- 
-void SHA224::final(unsigned char *digest)
-{
-    unsigned int block_nb;
-    unsigned int pm_len;
-    unsigned int len_b;
-    int i;
-    block_nb = (1 + ((SHA224_256_BLOCK_SIZE - 9)
-                     < (m_len % SHA224_256_BLOCK_SIZE)));
-    len_b = (m_tot_len + m_len) << 3;
-    pm_len = block_nb << 6;
-    memset(m_block + m_len, 0, pm_len - m_len);
-    m_block[m_len] = 0x80;
-    SHA2_UNPACK32(len_b, m_block + pm_len - 4);
-    transform(m_block, block_nb);
-    for (i = 0 ; i < 7; i++) {
-        SHA2_UNPACK32(m_h[i], &digest[i << 2]);
-    }
-}
- 
-void SHA256::transform(const unsigned char *message, unsigned int block_nb)
-{
-    uint32 w[64];
-    uint32 wv[8];
-    uint32 t1, t2;
-    const unsigned char *sub_block;
-    int i;
-    int j;
-    for (i = 0; i < (int) block_nb; i++) {
-        sub_block = message + (i << 6);
-        for (j = 0; j < 16; j++) {
-            SHA2_PACK32(&sub_block[j << 2], &w[j]);
-        }
-        for (j = 16; j < 64; j++) {
-            w[j] =  SHA256_F4(w[j -  2]) + w[j -  7] + SHA256_F3(w[j - 15]) + w[j - 16];
-        }
-        for (j = 0; j < 8; j++) {
-            wv[j] = m_h[j];
-        }
-        for (j = 0; j < 64; j++) {
-            t1 = wv[7] + SHA256_F2(wv[4]) + SHA2_CH(wv[4], wv[5], wv[6])
-                + sha256_k[j] + w[j];
-            t2 = SHA256_F1(wv[0]) + SHA2_MAJ(wv[0], wv[1], wv[2]);
-            wv[7] = wv[6];
-            wv[6] = wv[5];
-            wv[5] = wv[4];
-            wv[4] = wv[3] + t1;
-            wv[3] = wv[2];
-            wv[2] = wv[1];
-            wv[1] = wv[0];
-            wv[0] = t1 + t2;
-        }
-        for (j = 0; j < 8; j++) {
-            m_h[j] += wv[j];
-        }
-    }
-}
- 
-void SHA256::init()
-{
-    m_h[0] = 0x6a09e667;
-    m_h[1] = 0xbb67ae85;
-    m_h[2] = 0x3c6ef372;
-    m_h[3] = 0xa54ff53a;
-    m_h[4] = 0x510e527f;
-    m_h[5] = 0x9b05688c;
-    m_h[6] = 0x1f83d9ab;
-    m_h[7] = 0x5be0cd19;
-    m_len = 0;
-    m_tot_len = 0;
-}
- 
-void SHA256::update(const unsigned char *message, unsigned int len)
-{
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
-    const unsigned char *shifted_message;
-    tmp_len = SHA224_256_BLOCK_SIZE - m_len;
-    rem_len = len < tmp_len ? len : tmp_len;
-    memcpy(&m_block[m_len], message, rem_len);
-    if (m_len + len < SHA224_256_BLOCK_SIZE) {
-        m_len += len;
-        return;
-    }
-    new_len = len - rem_len;
-    block_nb = new_len / SHA224_256_BLOCK_SIZE;
-    shifted_message = message + rem_len;
-    transform(m_block, 1);
-    transform(shifted_message, block_nb);
-    rem_len = new_len % SHA224_256_BLOCK_SIZE;
-    memcpy(m_block, &shifted_message[block_nb << 6], rem_len);
-    m_len = rem_len;
-    m_tot_len += (block_nb + 1) << 6;
-}
- 
-void SHA256::final(unsigned char *digest)
-{
-    unsigned int block_nb;
-    unsigned int pm_len;
-    unsigned int len_b;
-    int i;
-    block_nb = (1 + ((SHA224_256_BLOCK_SIZE - 9)
-                     < (m_len % SHA224_256_BLOCK_SIZE)));
-    len_b = (m_tot_len + m_len) << 3;
-    pm_len = block_nb << 6;
-    memset(m_block + m_len, 0, pm_len - m_len);
-    m_block[m_len] = 0x80;
-    SHA2_UNPACK32(len_b, m_block + pm_len - 4);
-    transform(m_block, block_nb);
-    for (i = 0 ; i < 8; i++) {
-        SHA2_UNPACK32(m_h[i], &digest[i << 2]);
-    }
-}
- 
-void SHA384::init()
-{
-    m_h[0] = 0xcbbb9d5dc1059ed8ULL;
-    m_h[1] = 0x629a292a367cd507ULL;
-    m_h[2] = 0x9159015a3070dd17ULL;
-    m_h[3] = 0x152fecd8f70e5939ULL;
-    m_h[4] = 0x67332667ffc00b31ULL;
-    m_h[5] = 0x8eb44a8768581511ULL;
-    m_h[6] = 0xdb0c2e0d64f98fa7ULL;
-    m_h[7] = 0x47b5481dbefa4fa4ULL;
-    m_len = 0;
-    m_tot_len = 0;
-}
- 
-void SHA384::update(const unsigned char *message, unsigned int len)
-{
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
-    const unsigned char *shifted_message;
-    tmp_len = SHA384_512_BLOCK_SIZE - m_len;
-    rem_len = len < tmp_len ? len : tmp_len;
-    memcpy(&m_block[m_len], message, rem_len);
-    if (m_len + len < SHA384_512_BLOCK_SIZE) {
-        m_len += len;
-        return;
-    }
-    new_len = len - rem_len;
-    block_nb = new_len / SHA384_512_BLOCK_SIZE;
-    shifted_message = message + rem_len;
-    transform(m_block, 1);
-    transform(shifted_message, block_nb);
-    rem_len = new_len % SHA384_512_BLOCK_SIZE;
-    memcpy(m_block, &shifted_message[block_nb << 7], rem_len);
-    m_len = rem_len;
-    m_tot_len += (block_nb + 1) << 7;
-}
- 
-void SHA384::final(unsigned char *digest)
-{
-    unsigned int block_nb;
-    unsigned int pm_len;
-    unsigned int len_b;
-    int i;
-    block_nb = (1 + ((SHA384_512_BLOCK_SIZE - 17)
-                     < (m_len % SHA384_512_BLOCK_SIZE)));
-    len_b = (m_tot_len + m_len) << 3;
-    pm_len = block_nb << 7;
-    memset(m_block + m_len, 0, pm_len - m_len);
-    m_block[m_len] = 0x80;
-    SHA2_UNPACK32(len_b, m_block + pm_len - 4);
-    transform(m_block, block_nb);
-    for (i = 0 ; i < 6; i++) {
-        SHA2_UNPACK64(m_h[i], &digest[i << 3]);
-    }
-}
- 
-void SHA512::transform(const unsigned char *message, unsigned int block_nb)
-{
-    uint64 w[80];
-    uint64 wv[8];
-    uint64 t1, t2;
-    const unsigned char *sub_block;
-    int i, j;
-    for (i = 0; i < (int) block_nb; i++) {
-        sub_block = message + (i << 7);
-        for (j = 0; j < 16; j++) {
-            SHA2_PACK64(&sub_block[j << 3], &w[j]);
-        }
-        for (j = 16; j < 80; j++) {
-            w[j] =  SHA512_F4(w[j -  2]) + w[j -  7] + SHA512_F3(w[j - 15]) + w[j - 16];
-        }
-        for (j = 0; j < 8; j++) {
-            wv[j] = m_h[j];
-        }
-        for (j = 0; j < 80; j++) {
-            t1 = wv[7] + SHA512_F2(wv[4]) + SHA2_CH(wv[4], wv[5], wv[6])
-                + sha512_k[j] + w[j];
-            t2 = SHA512_F1(wv[0]) + SHA2_MAJ(wv[0], wv[1], wv[2]);
-            wv[7] = wv[6];
-            wv[6] = wv[5];
-            wv[5] = wv[4];
-            wv[4] = wv[3] + t1;
-            wv[3] = wv[2];
-            wv[2] = wv[1];
-            wv[1] = wv[0];
-            wv[0] = t1 + t2;
-        }
-        for (j = 0; j < 8; j++) {
-            m_h[j] += wv[j];
-        }
- 
-    }
-}
- 
-void SHA512::init()
-{
-    m_h[0] = 0x6a09e667f3bcc908ULL;
-    m_h[1] = 0xbb67ae8584caa73bULL;
-    m_h[2] = 0x3c6ef372fe94f82bULL;
-    m_h[3] = 0xa54ff53a5f1d36f1ULL;
-    m_h[4] = 0x510e527fade682d1ULL;
-    m_h[5] = 0x9b05688c2b3e6c1fULL;
-    m_h[6] = 0x1f83d9abfb41bd6bULL;
-    m_h[7] = 0x5be0cd19137e2179ULL;
-    m_len = 0;
-    m_tot_len = 0;
-}
- 
-void SHA512::update(const unsigned char *message, unsigned int len)
-{
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
-    const unsigned char *shifted_message;
-    tmp_len = SHA384_512_BLOCK_SIZE - m_len;
-    rem_len = len < tmp_len ? len : tmp_len;
-    memcpy(&m_block[m_len], message, rem_len);
-    if (m_len + len < SHA384_512_BLOCK_SIZE) {
-        m_len += len;
-        return;
-    }
-    new_len = len - rem_len;
-    block_nb = new_len / SHA384_512_BLOCK_SIZE;
-    shifted_message = message + rem_len;
-    transform(m_block, 1);
-    transform(shifted_message, block_nb);
-    rem_len = new_len % SHA384_512_BLOCK_SIZE;
-    memcpy(m_block, &shifted_message[block_nb << 7], rem_len);
-    m_len = rem_len;
-    m_tot_len += (block_nb + 1) << 7;
-}
- 
-void SHA512::final(unsigned char *digest)
-{
-    unsigned int block_nb;
-    unsigned int pm_len;
-    unsigned int len_b;
-    int i;
-    block_nb = 1 + ((SHA384_512_BLOCK_SIZE - 17)
-                     < (m_len % SHA384_512_BLOCK_SIZE));
-    len_b = (m_tot_len + m_len) << 3;
-    pm_len = block_nb << 7;
-    memset(m_block + m_len, 0, pm_len - m_len);
-    m_block[m_len] = 0x80;
-    SHA2_UNPACK32(len_b, m_block + pm_len - 4);
-    transform(m_block, block_nb);
-    for (i = 0 ; i < 8; i++) {
-        SHA2_UNPACK64(m_h[i], &digest[i << 3]);
-    }
-}
- 
-std::string sha224(std::string input)
-{
-    unsigned char digest[SHA224::DIGEST_SIZE];
-    memset(digest,0,SHA224::DIGEST_SIZE);
-    SHA224 ctx = SHA224();
-    ctx.init();
-    ctx.update((unsigned char*)input.c_str(), (unsigned int)input.length());
-    ctx.final(digest);
-	
-    char buf[2*SHA224::DIGEST_SIZE+1];
-    buf[2*SHA224::DIGEST_SIZE] = 0;
-    for (int i = 0; i < SHA224::DIGEST_SIZE; i++)
-        sprintf(buf+i*2, "%02x", digest[i]);
-    return std::string(buf);
-}
- 
-std::string sha256(std::string input)
-{
-    unsigned char digest[SHA256::DIGEST_SIZE];
-    memset(digest,0,SHA256::DIGEST_SIZE);
- 
-    SHA256 ctx = SHA256();
-    ctx.init();
-    ctx.update( (unsigned char*)input.c_str(), (unsigned int)input.length());
-    ctx.final(digest);
- 
-    char buf[2*SHA256::DIGEST_SIZE+1];
-    buf[2*SHA256::DIGEST_SIZE] = 0;
-    for (int i = 0; i < SHA256::DIGEST_SIZE; i++)
-        sprintf(buf+i*2, "%02x", digest[i]);
-    return std::string(buf);
-}
- 
-std::string sha384(std::string input)
-{
-    unsigned char digest[SHA384::DIGEST_SIZE];
-    memset(digest,0,SHA384::DIGEST_SIZE);
-    SHA384 ctx = SHA384();
-    ctx.init();
-    ctx.update((unsigned char*)input.c_str(), (unsigned int)input.length());
-    ctx.final(digest);
- 
-    char buf[2*SHA384::DIGEST_SIZE+1];
-    buf[2*SHA384::DIGEST_SIZE] = 0;
-    for (int i = 0; i < SHA384::DIGEST_SIZE; i++)
-        sprintf(buf+i*2, "%02x", digest[i]);
-    return std::string(buf);
-}
- 
-std::string sha512(std::string input)
-{
-    unsigned char digest[SHA512::DIGEST_SIZE];
-    memset(digest,0,SHA512::DIGEST_SIZE);
-    SHA512 ctx = SHA512();
-    ctx.init();
-    ctx.update((unsigned char*)input.c_str(), (unsigned int)input.length());
-    ctx.final(digest);
- 
-    char buf[2*SHA512::DIGEST_SIZE+1];
-    buf[2*SHA512::DIGEST_SIZE] = 0;
-    for (int i = 0; i < SHA512::DIGEST_SIZE; i++)
-        sprintf(buf+i*2, "%02x", digest[i]);
-    return std::string(buf);
-}
 
-/*
- * Updated to C++, zedwood.com 2012
- * Based on Olivier Gay's version
- * See Modified BSD License below:
- *
- * FIPS 180-2 SHA-224/256/384/512 implementation
- * Issue date:  04/30/2005
- * http://www.ouah.org/ogay/sha2/
- *
- * Copyright (C) 2005, 2007 Olivier Gay <olivier.gay@a3.epfl.ch>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the project nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
+
+
+	constexpr const unsigned int sha256_k[ 64 ] = //UL = uint32
+	{ 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+	 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+	 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+	 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+	 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+	 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+	 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+	 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+	 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+	 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+	 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+	 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+	 0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+	 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+	 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+	 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2 };
+	constexpr const unsigned long long sha512_k[ 80 ] = //ULL = uint64
+	{ 0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL,
+	 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
+	 0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
+	 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
+	 0xd807aa98a3030242ULL, 0x12835b0145706fbeULL,
+	 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
+	 0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL,
+	 0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
+	 0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL,
+	 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
+	 0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL,
+	 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
+	 0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL,
+	 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
+	 0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL,
+	 0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
+	 0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL,
+	 0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
+	 0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL,
+	 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
+	 0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL,
+	 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
+	 0xd192e819d6ef5218ULL, 0xd69906245565a910ULL,
+	 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
+	 0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL,
+	 0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
+	 0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL,
+	 0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
+	 0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL,
+	 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+	 0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL,
+	 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
+	 0xca273eceea26619cULL, 0xd186b8c721c0c207ULL,
+	 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
+	 0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL,
+	 0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
+	 0x28db77f523047d84ULL, 0x32caab7b40c72493ULL,
+	 0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
+	 0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL,
+	 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL };
+
+	void SHA224::init()
+	{
+		memset( m_digest, 0, sizeof( m_digest ) );
+		m_h[ 0 ] = 0xc1059ed8;
+		m_h[ 1 ] = 0x367cd507;
+		m_h[ 2 ] = 0x3070dd17;
+		m_h[ 3 ] = 0xf70e5939;
+		m_h[ 4 ] = 0xffc00b31;
+		m_h[ 5 ] = 0x68581511;
+		m_h[ 6 ] = 0x64f98fa7;
+		m_h[ 7 ] = 0xbefa4fa4;
+		m_len = 0;
+		m_tot_len = 0;
+	}
+
+	void SHA224::transform( const unsigned char* message, unsigned int block_nb ) 
+	{
+		uint32 w[ 64 ];
+		uint32 wv[ 8 ];
+		uint32 t1, t2;
+		const unsigned char* sub_block;
+		int i;
+		int j;
+		for( i = 0; i < (int)block_nb; i++ )
+		{
+			sub_block = message + ( i << 6 );
+			for( j = 0; j < 16; j++ )
+			{
+				pack( &sub_block[ j << 2 ], w[ j ] );
+			}
+			for( j = 16; j < 64; j++ )
+			{
+				w[ j ] = SHA256_F4( w[ j - 2 ] ) + w[ j - 7 ] + SHA256_F3( w[ j - 15 ] ) + w[ j - 16 ];
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				wv[ j ] = m_h[ j ];
+			}
+			for( j = 0; j < 64; j++ )
+			{
+				t1 = wv[ 7 ] + SHA256_F2( wv[ 4 ] ) + SHA2_CH( wv[ 4 ], wv[ 5 ], wv[ 6 ] )
+					+ sha256_k[ j ] + w[ j ];
+				t2 = SHA256_F1( wv[ 0 ] ) + SHA2_MAJ( wv[ 0 ], wv[ 1 ], wv[ 2 ] );
+				wv[ 7 ] = wv[ 6 ];
+				wv[ 6 ] = wv[ 5 ];
+				wv[ 5 ] = wv[ 4 ];
+				wv[ 4 ] = wv[ 3 ] + t1;
+				wv[ 3 ] = wv[ 2 ];
+				wv[ 2 ] = wv[ 1 ];
+				wv[ 1 ] = wv[ 0 ];
+				wv[ 0 ] = t1 + t2;
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				m_h[ j ] += wv[ j ];
+			}
+		}
+	}
+
+
+	void SHA224::update( const unsigned char* message, unsigned int len )
+	{
+		unsigned int block_nb;
+		unsigned int new_len, rem_len, tmp_len;
+		const unsigned char* shifted_message;
+		tmp_len = m_block_size - m_len;
+		rem_len = len < tmp_len ? len : tmp_len;
+		memcpy( &m_block[ m_len ], message, rem_len );
+		if( m_len + len < m_block_size )
+		{
+			m_len += len;
+			return;
+		}
+		new_len = len - rem_len;
+		block_nb = new_len / m_block_size;
+		shifted_message = message + rem_len;
+		transform( m_block, 1 );
+		transform( shifted_message, block_nb );
+		rem_len = new_len % m_block_size;
+		memcpy( m_block, &shifted_message[ block_nb << 6 ], rem_len );
+		m_len = rem_len;
+		m_tot_len += ( block_nb + 1 ) << 6;
+	}
+
+	void SHA224::final( )
+	{
+		unsigned int block_nb;
+		unsigned int pm_len;
+		unsigned int len_b;
+		int i;
+		block_nb = ( 1 + ( ( m_block_size - 9 )
+					 < ( m_len % m_block_size ) ) );
+		len_b = ( m_tot_len + m_len ) << 3;
+		pm_len = block_nb << 6;
+		memset( m_block + m_len, 0, pm_len - m_len );
+		m_block[ m_len ] = 0x80;
+		unpack( len_b, m_block + pm_len - 4 );
+		transform( m_block, block_nb );
+		for( i = 0; i < 7; i++ )
+		{
+			unpack( m_h[ i ], &m_digest[ i << 2 ] );
+		}
+	}
+
+	void SHA256::transform( const unsigned char* message, unsigned int block_nb )
+	{
+		uint32 w[ 64 ];
+		uint32 wv[ 8 ];
+		uint32 t1, t2;
+		const unsigned char* sub_block;
+		int i;
+		int j;
+		for( i = 0; i < (int)block_nb; i++ )
+		{
+			sub_block = message + ( i << 6 );
+			for( j = 0; j < 16; j++ )
+			{
+				pack( &sub_block[ j << 2 ], w[ j ] );
+			}
+			for( j = 16; j < 64; j++ )
+			{
+				w[ j ] = SHA256_F4( w[ j - 2 ] ) + w[ j - 7 ] + SHA256_F3( w[ j - 15 ] ) + w[ j - 16 ];
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				wv[ j ] = m_h[ j ];
+			}
+			for( j = 0; j < 64; j++ )
+			{
+				t1 = wv[ 7 ] + SHA256_F2( wv[ 4 ] ) + SHA2_CH( wv[ 4 ], wv[ 5 ], wv[ 6 ] )
+					+ sha256_k[ j ] + w[ j ];
+				t2 = SHA256_F1( wv[ 0 ] ) + SHA2_MAJ( wv[ 0 ], wv[ 1 ], wv[ 2 ] );
+				wv[ 7 ] = wv[ 6 ];
+				wv[ 6 ] = wv[ 5 ];
+				wv[ 5 ] = wv[ 4 ];
+				wv[ 4 ] = wv[ 3 ] + t1;
+				wv[ 3 ] = wv[ 2 ];
+				wv[ 2 ] = wv[ 1 ];
+				wv[ 1 ] = wv[ 0 ];
+				wv[ 0 ] = t1 + t2;
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				m_h[ j ] += wv[ j ];
+			}
+		}
+	}
+
+	void SHA256::init()
+	{
+		memset( m_digest, 0, sizeof( m_digest ) );
+		m_h[ 0 ] = 0x6a09e667;
+		m_h[ 1 ] = 0xbb67ae85;
+		m_h[ 2 ] = 0x3c6ef372;
+		m_h[ 3 ] = 0xa54ff53a;
+		m_h[ 4 ] = 0x510e527f;
+		m_h[ 5 ] = 0x9b05688c;
+		m_h[ 6 ] = 0x1f83d9ab;
+		m_h[ 7 ] = 0x5be0cd19;
+		m_len = 0;
+		m_tot_len = 0;
+	}
+
+	void SHA256::update( const unsigned char* message, unsigned int len )
+	{
+		unsigned int block_nb;
+		unsigned int new_len, rem_len, tmp_len;
+		const unsigned char* shifted_message;
+		tmp_len = m_block_size - m_len;
+		rem_len = len < tmp_len ? len : tmp_len;
+		memcpy( &m_block[ m_len ], message, rem_len );
+		if( m_len + len < m_block_size )
+		{
+			m_len += len;
+			return;
+		}
+		new_len = len - rem_len;
+		block_nb = new_len / m_block_size;
+		shifted_message = message + rem_len;
+		transform( m_block, 1 );
+		transform( shifted_message, block_nb );
+		rem_len = new_len % m_block_size;
+		memcpy( m_block, &shifted_message[ block_nb << 6 ], rem_len );
+		m_len = rem_len;
+		m_tot_len += ( block_nb + 1 ) << 6;
+	}
+
+	void SHA256::final()
+	{
+		unsigned int block_nb;
+		unsigned int pm_len;
+		unsigned int len_b;
+		int i;
+		block_nb = ( 1 + ( ( m_block_size - 9 )
+					 < ( m_len % m_block_size ) ) );
+		len_b = ( m_tot_len + m_len ) << 3;
+		pm_len = block_nb << 6;
+		memset( m_block + m_len, 0, pm_len - m_len );
+		m_block[ m_len ] = 0x80;
+		unpack( len_b, m_block + pm_len - 4 );
+		transform( m_block, block_nb );
+		for( i = 0; i < 8; i++ )
+		{
+			unpack( m_h[ i ], &m_digest[ i << 2 ] );
+		}
+	}
+
+	void SHA384::init()
+	{
+		memset( m_digest, 0, sizeof( m_digest ) );
+		m_h[ 0 ] = 0xcbbb9d5dc1059ed8ULL;
+		m_h[ 1 ] = 0x629a292a367cd507ULL;
+		m_h[ 2 ] = 0x9159015a3070dd17ULL;
+		m_h[ 3 ] = 0x152fecd8f70e5939ULL;
+		m_h[ 4 ] = 0x67332667ffc00b31ULL;
+		m_h[ 5 ] = 0x8eb44a8768581511ULL;
+		m_h[ 6 ] = 0xdb0c2e0d64f98fa7ULL;
+		m_h[ 7 ] = 0x47b5481dbefa4fa4ULL;
+		m_len = 0;
+		m_tot_len = 0;
+	}
+
+	void SHA384::update( const unsigned char* message, unsigned int len )
+	{
+		unsigned int block_nb;
+		unsigned int new_len, rem_len, tmp_len;
+		const unsigned char* shifted_message;
+		tmp_len = m_block_size - m_len;
+		rem_len = len < tmp_len ? len : tmp_len;
+		memcpy( &m_block[ m_len ], message, rem_len );
+		if( m_len + len < m_block_size )
+		{
+			m_len += len;
+			return;
+		}
+		new_len = len - rem_len;
+		block_nb = new_len / m_block_size;
+		shifted_message = message + rem_len;
+		transform( m_block, 1 );
+		transform( shifted_message, block_nb );
+		rem_len = new_len % m_block_size;
+		memcpy( m_block, &shifted_message[ block_nb << 7 ], rem_len );
+		m_len = rem_len;
+		m_tot_len += ( block_nb + 1 ) << 7;
+	}
+
+	void SHA384::final()
+	{
+		unsigned int block_nb;
+		unsigned int pm_len;
+		unsigned int len_b;
+		int i;
+		block_nb = ( 1 + ( ( m_block_size - 17 )
+					 < ( m_len % m_block_size ) ) );
+		len_b = ( m_tot_len + m_len ) << 3;
+		pm_len = block_nb << 7;
+		memset( m_block + m_len, 0, pm_len - m_len );
+		m_block[ m_len ] = 0x80;
+		unpack( len_b, m_block + pm_len - 4 );
+		transform( m_block, block_nb );
+		for( i = 0; i < 6; i++ )
+		{
+			unpack( m_h[ i ], &m_digest[ i << 3 ] );
+		}
+	}
+
+	void SHA384::transform( const unsigned char* message, unsigned int block_nb )
+	{
+		uint64 w[ 80 ];
+		uint64 wv[ 8 ];
+		uint64 t1, t2;
+		const unsigned char* sub_block;
+		int i, j;
+		for( i = 0; i < (int)block_nb; i++ )
+		{
+			sub_block = message + ( i << 7 );
+			for( j = 0; j < 16; j++ )
+			{
+				pack( &sub_block[ j << 3 ], w[ j ] );
+			}
+			for( j = 16; j < 80; j++ )
+			{
+				w[ j ] = SHA512_F4( w[ j - 2 ] ) + w[ j - 7 ] + SHA512_F3( w[ j - 15 ] ) + w[ j - 16 ];
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				wv[ j ] = m_h[ j ];
+			}
+			for( j = 0; j < 80; j++ )
+			{
+				t1 = wv[ 7 ] + SHA512_F2( wv[ 4 ] ) + SHA2_CH( wv[ 4 ], wv[ 5 ], wv[ 6 ] )
+					+ sha512_k[ j ] + w[ j ];
+				t2 = SHA512_F1( wv[ 0 ] ) + SHA2_MAJ( wv[ 0 ], wv[ 1 ], wv[ 2 ] );
+				wv[ 7 ] = wv[ 6 ];
+				wv[ 6 ] = wv[ 5 ];
+				wv[ 5 ] = wv[ 4 ];
+				wv[ 4 ] = wv[ 3 ] + t1;
+				wv[ 3 ] = wv[ 2 ];
+				wv[ 2 ] = wv[ 1 ];
+				wv[ 1 ] = wv[ 0 ];
+				wv[ 0 ] = t1 + t2;
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				m_h[ j ] += wv[ j ];
+			}
+
+		}
+	}
+
+
+	void SHA512::transform( const unsigned char* message, unsigned int block_nb )
+	{
+		uint64 w[ 80 ];
+		uint64 wv[ 8 ];
+		uint64 t1, t2;
+		const unsigned char* sub_block;
+		int i, j;
+		for( i = 0; i < (int)block_nb; i++ )
+		{
+			sub_block = message + ( i << 7 );
+			for( j = 0; j < 16; j++ )
+			{
+				pack( &sub_block[ j << 3 ], w[ j ] );
+			}
+			for( j = 16; j < 80; j++ )
+			{
+				w[ j ] = SHA512_F4( w[ j - 2 ] ) + w[ j - 7 ] + SHA512_F3( w[ j - 15 ] ) + w[ j - 16 ];
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				wv[ j ] = m_h[ j ];
+			}
+			for( j = 0; j < 80; j++ )
+			{
+				t1 = wv[ 7 ] + SHA512_F2( wv[ 4 ] ) + SHA2_CH( wv[ 4 ], wv[ 5 ], wv[ 6 ] )
+					+ sha512_k[ j ] + w[ j ];
+				t2 = SHA512_F1( wv[ 0 ] ) + SHA2_MAJ( wv[ 0 ], wv[ 1 ], wv[ 2 ] );
+				wv[ 7 ] = wv[ 6 ];
+				wv[ 6 ] = wv[ 5 ];
+				wv[ 5 ] = wv[ 4 ];
+				wv[ 4 ] = wv[ 3 ] + t1;
+				wv[ 3 ] = wv[ 2 ];
+				wv[ 2 ] = wv[ 1 ];
+				wv[ 1 ] = wv[ 0 ];
+				wv[ 0 ] = t1 + t2;
+			}
+			for( j = 0; j < 8; j++ )
+			{
+				m_h[ j ] += wv[ j ];
+			}
+
+		}
+	}
+
+	void SHA512::init()
+	{
+		memset( m_digest, 0, sizeof( m_digest ) );
+		m_h[ 0 ] = 0x6a09e667f3bcc908ULL;
+		m_h[ 1 ] = 0xbb67ae8584caa73bULL;
+		m_h[ 2 ] = 0x3c6ef372fe94f82bULL;
+		m_h[ 3 ] = 0xa54ff53a5f1d36f1ULL;
+		m_h[ 4 ] = 0x510e527fade682d1ULL;
+		m_h[ 5 ] = 0x9b05688c2b3e6c1fULL;
+		m_h[ 6 ] = 0x1f83d9abfb41bd6bULL;
+		m_h[ 7 ] = 0x5be0cd19137e2179ULL;
+		m_len = 0;
+		m_tot_len = 0;
+	}
+
+	void SHA512::update( const unsigned char* message, unsigned int len )
+	{
+		unsigned int block_nb;
+		unsigned int new_len, rem_len, tmp_len;
+		const unsigned char* shifted_message;
+		tmp_len = m_block_size - m_len;
+		rem_len = len < tmp_len ? len : tmp_len;
+		memcpy( &m_block[ m_len ], message, rem_len );
+		if( m_len + len < m_block_size )
+		{
+			m_len += len;
+			return;
+		}
+		new_len = len - rem_len;
+		block_nb = new_len / m_block_size;
+		shifted_message = message + rem_len;
+		transform( m_block, 1 );
+		transform( shifted_message, block_nb );
+		rem_len = new_len % m_block_size;
+		memcpy( m_block, &shifted_message[ block_nb << 7 ], rem_len );
+		m_len = rem_len;
+		m_tot_len += ( block_nb + 1 ) << 7;
+	}
+
+	void SHA512::final()
+	{
+		unsigned int block_nb;
+		unsigned int pm_len;
+		unsigned int len_b;
+		int i;
+		block_nb = 1 + ( ( m_block_size - 17 )
+						 < ( m_len % m_block_size ) );
+		len_b = ( m_tot_len + m_len ) << 3;
+		pm_len = block_nb << 7;
+		memset( m_block + m_len, 0, pm_len - m_len );
+		m_block[ m_len ] = 0x80;
+		unpack( len_b, m_block + pm_len - 4 );
+		transform( m_block, block_nb );
+		for( i = 0; i < 8; i++ )
+		{
+			unpack( m_h[ i ], &m_digest[ i << 3 ] );
+		}
+	}
+
+	
+	std::string sha224( std::string input )
+	{
+		SHA224 ctx = SHA224();
+		ctx.calculate( (unsigned char*)input.c_str(), (unsigned int)input.length() );
+		return ctx.toHexString();
+	}
+
+	std::string sha256( std::string input )
+	{
+		SHA256 ctx = SHA256();
+		ctx.calculate( (unsigned char*)input.c_str(), (unsigned int)input.length() );
+		return ctx.toHexString();
+	}
+
+	std::string sha384( std::string input )
+	{
+		
+		SHA384 ctx = SHA384();
+		ctx.calculate( (unsigned char*)input.c_str(), (unsigned int)input.length() );
+		return ctx.toHexString();
+	}
+
+	std::string sha512( std::string input )
+	{
+		SHA512 ctx = SHA512();
+		ctx.calculate( (unsigned char*)input.c_str(), (unsigned int)input.length() );
+		return ctx.toHexString();
+	}
+
+	/*
+	 * Updated to C++, zedwood.com 2012
+	 * Based on Olivier Gay's version
+	 * See Modified BSD License below:
+	 *
+	 * FIPS 180-2 SHA-224/256/384/512 implementation
+	 * Issue date:  04/30/2005
+	 * http://www.ouah.org/ogay/sha2/
+	 *
+	 * Copyright (C) 2005, 2007 Olivier Gay <olivier.gay@a3.epfl.ch>
+	 * All rights reserved.
+	 *
+	 * Redistribution and use in source and binary forms, with or without
+	 * modification, are permitted provided that the following conditions
+	 * are met:
+	 * 1. Redistributions of source code must retain the above copyright
+	 *    notice, this list of conditions and the following disclaimer.
+	 * 2. Redistributions in binary form must reproduce the above copyright
+	 *    notice, this list of conditions and the following disclaimer in the
+	 *    documentation and/or other materials provided with the distribution.
+	 * 3. Neither the name of the project nor the names of its contributors
+	 *    may be used to endorse or promote products derived from this software
+	 *    without specific prior written permission.
+	 *
+	 * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+	 * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+	 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+	 * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+	 * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+	 * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+	 * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	 * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	 * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+	 * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+	 * SUCH DAMAGE.
+	 */

--- a/cpp/OpenGL/Utils/SHA2.h
+++ b/cpp/OpenGL/Utils/SHA2.h
@@ -70,8 +70,8 @@
         void transform( const unsigned char* message, unsigned int block_nb ) override;
     };
 
-        constexpr const unsigned int SHA384_512_BLOCK_SIZE = ( 1024 / 8 );
-        constexpr const unsigned int SHA512_DIGEST_SIZE = ( 512 / 8 );
+    constexpr const unsigned int SHA384_512_BLOCK_SIZE = ( 1024 / 8 );
+    constexpr const unsigned int SHA512_DIGEST_SIZE = ( 512 / 8 );
     constexpr const unsigned int SHA384_DIGEST_SIZE = ( 384 / 8 );
 
     class SHA512 : public SHA2<SHA384_512_BLOCK_SIZE,SHA512_DIGEST_SIZE, unsigned long long>

--- a/cpp/OpenGL/Utils/SHA2.h
+++ b/cpp/OpenGL/Utils/SHA2.h
@@ -1,166 +1,238 @@
 #pragma once
+#pragma once
 
 #include <string>
- 
-class SHA2
-{
-public:
-    virtual void init() = 0;
-    virtual void update(const unsigned char *message, unsigned int len) = 0;
-    virtual void final(unsigned char *digest) = 0;
- 
-protected:
-    typedef unsigned char uint8;
-    typedef unsigned int uint32;
-    typedef unsigned long long uint64;
-};
- 
-class SHA256 : public SHA2
-{
-protected:
-    const static uint32 sha256_k[];
-    static const unsigned int SHA224_256_BLOCK_SIZE = (512/8);
-public:
-    void init();
-    void update(const unsigned char *message, unsigned int len);
-    void final(unsigned char *digest);
-    static const unsigned int DIGEST_SIZE = ( 256 / 8);
-protected:
-    void transform(const unsigned char *message, unsigned int block_nb);
-    unsigned int m_tot_len;
-    unsigned int m_len;
-    unsigned char m_block[2*SHA224_256_BLOCK_SIZE];
-    uint32 m_h[8];
-};
- 
- 
-class SHA224 : public SHA256
-{
-public:
-    void init();
-    void update(const unsigned char *message, unsigned int len);
-    void final(unsigned char *digest);
-    static const unsigned int DIGEST_SIZE = ( 224 / 8);
-};
- 
- 
-class SHA512 : public SHA2
-{
-protected:
-    const static uint64 sha512_k[];
-    static const unsigned int SHA384_512_BLOCK_SIZE = (1024/8);
- 
-public:
-    void init();
-    void update(const unsigned char *message, unsigned int len);
-    void final(unsigned char *digest);
-    static const unsigned int DIGEST_SIZE = ( 512 / 8);
- 
-protected:
-    void transform(const unsigned char *message, unsigned int block_nb);
-    unsigned int m_tot_len;
-    unsigned int m_len;
-    unsigned char m_block[2 * SHA384_512_BLOCK_SIZE];
-    uint64 m_h[8];
-};
- 
-class SHA384 : public SHA512
-{
-public:
-    void init();
-    void update(const unsigned char *message, unsigned int len);
-    void final(unsigned char *digest);
-    static const unsigned int DIGEST_SIZE = ( 384 / 8);
-};
- 
-std::string sha224(std::string input);
-std::string sha256(std::string input);
-std::string sha384(std::string input);
-std::string sha512(std::string input);
- 
+#include <vector>
+
+    template<size_t blocksize,size_t digestsize, typename seed_type>
+    class SHA2
+    {
+    public:
+        void calculate( const unsigned char* message, unsigned int len )
+        {
+            this->init();
+            this->update( message, len );
+            this->final();
+        }
+        std::string toHexString();
+        void getDigest( std::vector<unsigned char>& digest );
+
+    protected:
+        typedef unsigned char uint8;
+        typedef unsigned int uint32;
+        typedef unsigned long long uint64;
+
+        virtual void init() = 0;
+        virtual void update( const unsigned char* message, unsigned int len ) = 0;
+        virtual void final() = 0;
+        virtual void transform( const unsigned char* message, unsigned int block_nb ) = 0;
+
+        const unsigned int m_block_size = blocksize;
+        uint8 m_digest[ digestsize ]{};
+        unsigned char m_block[ 2 * blocksize ]{};
+        seed_type m_h[ 8 ]{};
+        unsigned int m_tot_len=0;
+        unsigned int m_len=0;
+
+        void unpack( uint32 x, unsigned char* str );
+        void pack( const unsigned char* str, uint32& x );
+
+        void unpack( uint64 x, unsigned char* str );
+        void pack( const unsigned char* str, uint64& x );
+
+    private:
+        // %02x
+        static void fillHex( unsigned char c, char& pos1, char& pos2 );
+    };
+        
+    constexpr const unsigned int SHA224_256_BLOCK_SIZE = ( 512 / 8 );
+    constexpr const unsigned int SHA256_DIGEST_SIZE = ( 256 / 8 );
+    constexpr const unsigned int SHA224_DIGEST_SIZE = ( 224 / 8 );
+
+    class SHA256 : public SHA2<SHA224_256_BLOCK_SIZE,SHA256_DIGEST_SIZE, unsigned int>
+    {
+    public:
+        void init() override;
+        void update( const unsigned char* message, unsigned int len ) override;
+        void final() override;
+    protected:
+        void transform( const unsigned char* message, unsigned int block_nb ) override;
+    };
+
+
+    class SHA224 : public SHA2<SHA224_256_BLOCK_SIZE,SHA224_DIGEST_SIZE, unsigned int>
+    {
+    public:
+        void init() override;
+        void update( const unsigned char* message, unsigned int len ) override;
+        void final() override;
+    protected:
+        void transform( const unsigned char* message, unsigned int block_nb ) override;
+    };
+
+        constexpr const unsigned int SHA384_512_BLOCK_SIZE = ( 1024 / 8 );
+        constexpr const unsigned int SHA512_DIGEST_SIZE = ( 512 / 8 );
+    constexpr const unsigned int SHA384_DIGEST_SIZE = ( 384 / 8 );
+
+    class SHA512 : public SHA2<SHA384_512_BLOCK_SIZE,SHA512_DIGEST_SIZE, unsigned long long>
+    {
+    public:
+        void init() override;
+        void update( const unsigned char* message, unsigned int len ) override;
+        void final() override;
+    protected:
+        void transform( const unsigned char* message, unsigned int block_nb );
+    };
+
+    class SHA384 : public SHA2<SHA384_512_BLOCK_SIZE,SHA384_DIGEST_SIZE, unsigned long long>
+    {
+    public:
+        void init();
+        void update( const unsigned char* message, unsigned int len );
+        void final();
+    protected:
+        void transform( const unsigned char* message, unsigned int block_nb ) override;
+    };
+
+    std::string sha224( std::string input );
+    std::string sha256( std::string input );
+    std::string sha384( std::string input );
+    std::string sha512( std::string input );
+
 #define SHA2_SHFR(x, n)    (x >> n)
 #define SHA2_ROTR(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))
 #define SHA2_ROTL(x, n)   ((x << n) | (x >> ((sizeof(x) << 3) - n)))
 #define SHA2_CH(x, y, z)  ((x & y) ^ (~x & z))
 #define SHA2_MAJ(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
+
 #define SHA256_F1(x) (SHA2_ROTR(x,  2) ^ SHA2_ROTR(x, 13) ^ SHA2_ROTR(x, 22))
 #define SHA256_F2(x) (SHA2_ROTR(x,  6) ^ SHA2_ROTR(x, 11) ^ SHA2_ROTR(x, 25))
 #define SHA256_F3(x) (SHA2_ROTR(x,  7) ^ SHA2_ROTR(x, 18) ^ SHA2_SHFR(x,  3))
 #define SHA256_F4(x) (SHA2_ROTR(x, 17) ^ SHA2_ROTR(x, 19) ^ SHA2_SHFR(x, 10))
+
 #define SHA512_F1(x) (SHA2_ROTR(x, 28) ^ SHA2_ROTR(x, 34) ^ SHA2_ROTR(x, 39))
 #define SHA512_F2(x) (SHA2_ROTR(x, 14) ^ SHA2_ROTR(x, 18) ^ SHA2_ROTR(x, 41))
 #define SHA512_F3(x) (SHA2_ROTR(x,  1) ^ SHA2_ROTR(x,  8) ^ SHA2_SHFR(x,  7))
 #define SHA512_F4(x) (SHA2_ROTR(x, 19) ^ SHA2_ROTR(x, 61) ^ SHA2_SHFR(x,  6))
-#define SHA2_UNPACK32(x, str)                 \
-{                                             \
-    *((str) + 3) = (uint8) ((x)      );       \
-    *((str) + 2) = (uint8) ((x) >>  8);       \
-    *((str) + 1) = (uint8) ((x) >> 16);       \
-    *((str) + 0) = (uint8) ((x) >> 24);       \
-}
-#define SHA2_PACK32(str, x)                   \
-{                                             \
-    *(x) =   ((uint32) *((str) + 3)      )    \
-           | ((uint32) *((str) + 2) <<  8)    \
-           | ((uint32) *((str) + 1) << 16)    \
-           | ((uint32) *((str) + 0) << 24);   \
-}
-#define SHA2_UNPACK64(x, str)                 \
-{                                             \
-    *((str) + 7) = (uint8) ((x)      );       \
-    *((str) + 6) = (uint8) ((x) >>  8);       \
-    *((str) + 5) = (uint8) ((x) >> 16);       \
-    *((str) + 4) = (uint8) ((x) >> 24);       \
-    *((str) + 3) = (uint8) ((x) >> 32);       \
-    *((str) + 2) = (uint8) ((x) >> 40);       \
-    *((str) + 1) = (uint8) ((x) >> 48);       \
-    *((str) + 0) = (uint8) ((x) >> 56);       \
-}
-#define SHA2_PACK64(str, x)                   \
-{                                             \
-    *(x) =   ((uint64) *((str) + 7)      )    \
-           | ((uint64) *((str) + 6) <<  8)    \
-           | ((uint64) *((str) + 5) << 16)    \
-           | ((uint64) *((str) + 4) << 24)    \
-           | ((uint64) *((str) + 3) << 32)    \
-           | ((uint64) *((str) + 2) << 40)    \
-           | ((uint64) *((str) + 1) << 48)    \
-           | ((uint64) *((str) + 0) << 56);   \
-}
 
-/*
- * Updated to C++, zedwood.com 2012
- * Based on Olivier Gay's version
- * See Modified BSD License below:
- *
- * FIPS 180-2 SHA-224/256/384/512 implementation
- * Issue date:  04/30/2005
- * http://www.ouah.org/ogay/sha2/
- *
- * Copyright (C) 2005, 2007 Olivier Gay <olivier.gay@a3.epfl.ch>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the project nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
+
+
+
+
+    // %02x
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    void SHA2<blocksize, digestsize, seed_type>::fillHex( unsigned char c, char& pos1, char& pos2 )
+    {
+        static const char* hex = "0123456789abcdef";
+
+        const short lower = ( c & 0x0F );
+        const short upper = ( c & 0xF0 ) >> 4;
+        pos1 = hex[ upper ];
+        pos2 = hex[ lower ];
+    }
+
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    void SHA2<blocksize, digestsize, seed_type>::unpack( uint32 x, unsigned char* str )
+    {
+        *( (str)+3 ) = (uint8)( ( x ) );
+        *( (str)+2 ) = (uint8)( ( x ) >> 8 );
+        *( (str)+1 ) = (uint8)( ( x ) >> 16 );
+        *( (str)+0 ) = (uint8)( ( x ) >> 24 );
+    }
+
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    void SHA2<blocksize, digestsize, seed_type>::pack( const unsigned char* str, uint32& x )
+    {
+        x = ( ( uint32 ) * ( (str)+3 ) )
+            | ( ( uint32 ) * ( (str)+2 ) << 8 )
+            | ( ( uint32 ) * ( (str)+1 ) << 16 )
+            | ( ( uint32 ) * ( (str)+0 ) << 24 );
+    }
+
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    void SHA2<blocksize, digestsize, seed_type>::unpack( uint64 x, unsigned char* str )
+    {
+        *( (str)+7 ) = (uint8)( ( x ) );
+        *( (str)+6 ) = (uint8)( ( x ) >> 8 );
+        *( (str)+5 ) = (uint8)( ( x ) >> 16 );
+        *( (str)+4 ) = (uint8)( ( x ) >> 24 );
+        *( (str)+3 ) = (uint8)( ( x ) >> 32 );
+        *( (str)+2 ) = (uint8)( ( x ) >> 40 );
+        *( (str)+1 ) = (uint8)( ( x ) >> 48 );
+        *( (str)+0 ) = (uint8)( ( x ) >> 56 );
+    }
+
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    void SHA2<blocksize, digestsize, seed_type>::pack( const unsigned char* str, uint64& x )
+    {
+        x = ( ( uint64 ) * ( (str)+7 ) )
+            | ( ( uint64 ) * ( (str)+6 ) << 8 )
+            | ( ( uint64 ) * ( (str)+5 ) << 16 )
+            | ( ( uint64 ) * ( (str)+4 ) << 24 )
+            | ( ( uint64 ) * ( (str)+3 ) << 32 )
+            | ( ( uint64 ) * ( (str)+2 ) << 40 )
+            | ( ( uint64 ) * ( (str)+1 ) << 48 )
+            | ( ( uint64 ) * ( (str)+0 ) << 56 );
+    }
+
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    std::string SHA2<blocksize, digestsize, seed_type>::toHexString()
+    {
+        char buf[ ( 2 * digestsize ) + 1 ]{};
+        char* t = &buf[ 0 ];
+
+        for( int i = 0; i < digestsize; ++i )
+        {
+            fillHex( m_digest[ i ], *t, *( t + 1 ) );
+            t++;
+            t++;
+        }
+        return std::string( buf );
+    }
+
+    template<size_t blocksize, size_t digestsize, typename seed_type>
+    void SHA2<blocksize, digestsize, seed_type>::getDigest( std::vector<SHA2::uint8>& digest )
+    {
+        digest.reserve( digestsize );
+        for( int i = 0; i < digestsize; ++i )
+        {
+            digest.emplace_back( m_digest[ i ] );
+        }
+    }
+
+    /*
+     * Updated to C++, zedwood.com 2012
+     * Based on Olivier Gay's version
+     * See Modified BSD License below:
+     *
+     * FIPS 180-2 SHA-224/256/384/512 implementation
+     * Issue date:  04/30/2005
+     * http://www.ouah.org/ogay/sha2/
+     *
+     * Copyright (C) 2005, 2007 Olivier Gay <olivier.gay@a3.epfl.ch>
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     * 1. Redistributions of source code must retain the above copyright
+     *    notice, this list of conditions and the following disclaimer.
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in the
+     *    documentation and/or other materials provided with the distribution.
+     * 3. Neither the name of the project nor the names of its contributors
+     *    may be used to endorse or promote products derived from this software
+     *    without specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+     * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+     * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+     * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+     * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+     * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+     * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     * SUCH DAMAGE.
+     */


### PR DESCRIPTION
impact: anscheinend gering, fand im gesamten lnc-ordner keine Verwendung des sha.

DigestBuffer in Sha2-Klasse gekapselt, verwendete digest und block-länge muss von aussen her nicht mehr bekannt sein.
Dimensionierung übernimmt Konstruktor, welcher die Größen per Template steuert.

Aufruf selbst sieht dann so aus:
std::string sha512( std::string input )
	{
		SHA512 ctx = SHA512();
		ctx.calculate( (unsigned char*)input.c_str(), (unsigned int)input.length() );
		return ctx.toHexString();
	}

Ob der gigantische Umbau weiterhin erwartungsgemäß läuft, wurde mittels unit_test sichergestellt.
https://github.com/blowfishfugu/gtest_sha_refactor/blob/master/TestSha.cpp

Performancegewinn durch Weglassen des sprintf ist bemerkbar (100000 mal Prüfsumme auf 'peach')
https://github.com/blowfishfugu/gtest_sha_refactor/blob/master/Results_ReleaseBuild.PNG
